### PR TITLE
Disabled keyboard notifications.

### DIFF
--- a/KCFloatingActionButton/KCFloatingActionButton.swift
+++ b/KCFloatingActionButton/KCFloatingActionButton.swift
@@ -491,14 +491,14 @@ public class KCFloatingActionButton: UIView {
     
     private func setObserver() {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "deviceOrientationDidChange:", name: UIDeviceOrientationDidChangeNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShow:", name:UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillHide:", name:UIKeyboardWillHideNotification, object: nil)
+//        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShow:", name:UIKeyboardWillShowNotification, object: nil)
+//        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillHide:", name:UIKeyboardWillHideNotification, object: nil)
     }
     
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIDeviceOrientationDidChangeNotification, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name:UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name:UIKeyboardWillHideNotification, object: nil)
+//        NSNotificationCenter.defaultCenter().removeObserver(self, name:UIKeyboardWillShowNotification, object: nil)
+//        NSNotificationCenter.defaultCenter().removeObserver(self, name:UIKeyboardWillHideNotification, object: nil)
     }
     
     public override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {

--- a/Sample/KCFloatingActionButton-Sample.xcodeproj/project.pbxproj
+++ b/Sample/KCFloatingActionButton-Sample.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 				TargetAttributes = {
 					B6F66E151BC1017F00E47769 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -284,6 +285,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kciter.KCFloatingActionButton;
 				PRODUCT_NAME = "KCFloatingActionButton-Sample";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -296,6 +298,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kciter.KCFloatingActionButton;
 				PRODUCT_NAME = "KCFloatingActionButton-Sample";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The KCFloatingActionButton widget no longer listens for keyboard presentation notifications. It will no longer auto adjust it’s Y position based on the visibility state of the on-screen keyboard. This was causing all sorts of constraint issues.